### PR TITLE
Fixed Rect2DComponent

### DIFF
--- a/Engine/Source/MCP/Components/Rect2DComponent.cpp
+++ b/Engine/Source/MCP/Components/Rect2DComponent.cpp
@@ -49,13 +49,9 @@ namespace mcp
             return false;
         }
 
+        // IRenderable Data.
         const auto layer =static_cast<RenderLayer>(renderableElement.GetAttribute<int>("layer"));
         const int zOrder = renderableElement.GetAttribute<int>("zOrder");
-
-        // IRenderable Data.
-        const auto* pRenderable = pRect2DElement->FirstChildElement("Renderable");
-        const RenderLayer layer = static_cast<RenderLayer>(pRenderable->IntAttribute("layer"));
-        const int zOrder = pRenderable->IntAttribute("zOrder");
 
         // Add the component
         auto* pRect2DComponent = pOwner->AddComponent<Rect2DComponent>(width, height, layer, zOrder);


### PR DESCRIPTION
- For some reason, some old code in the Rect2DComponent.cpp wasn't deleted, and it caused a compilation error.