### PR TITLE
Updated Message System API

### DIFF
--- a/Engine/Source/MCP/Components/Component.cpp
+++ b/Engine/Source/MCP/Components/Component.cpp
@@ -18,4 +18,37 @@ namespace mcp
     {
         return m_pOwner->GetScene()->GetMessageManager();
     }
+
+    //-----------------------------------------------------------------------------------------------------------------------------
+    //		NOTES:
+    //		
+    ///		@brief : Send out a message.
+    ///		@param messageId : Name of the message type you want to send.
+    //-----------------------------------------------------------------------------------------------------------------------------
+    void Component::SendMessage(const MessageId messageId)
+    {
+        m_pOwner->GetScene()->GetMessageManager()->QueueMessage(this, messageId);
+    }
+
+    //-----------------------------------------------------------------------------------------------------------------------------
+    //		NOTES:
+    //		
+    ///		@brief : Set this component to listen for a specific type of message.
+    ///		@param messageId : Name of the message that you want to listen to.
+    //-----------------------------------------------------------------------------------------------------------------------------
+    void Component::ListenForMessage(const MessageId messageId)
+    {
+        m_pOwner->GetScene()->GetMessageManager()->AddListener(this, messageId);
+    }
+
+    //-----------------------------------------------------------------------------------------------------------------------------
+    //		NOTES:
+    //		
+    ///		@brief : Stop listening to a specific message.
+    ///		@param messageId : Name of the message that you want to stop listening to.
+    //-----------------------------------------------------------------------------------------------------------------------------
+    void Component::StopListeningToMessage(const MessageId messageId) const
+    {
+        m_pOwner->GetScene()->GetMessageManager()->RemoveListener(this, messageId);
+    }
 }

--- a/Engine/Source/MCP/Components/Component.h
+++ b/Engine/Source/MCP/Components/Component.h
@@ -2,6 +2,7 @@
 // Component.h
 
 #include "ComponentFactory.h"
+#include "MCP/Core/Event/Message.h"
 
 namespace mcp
 {
@@ -30,7 +31,7 @@ private:                                                                        
 public:                                                                                                                                                 \
     static mcp::ComponentTypeId GetStaticTypeId() { return kComponentTypeId; }                                                                          \
     virtual mcp::ComponentTypeId GetTypeId() const override { return kComponentTypeId; }                                                                \
-private:
+private:                                                                                                                                                \
 
     class Component
     {
@@ -79,5 +80,10 @@ private:
         [[nodiscard]] Object* GetOwner() const { return m_pOwner; }
         [[nodiscard]] MessageManager* GetMessageManager() const;
         [[nodiscard]] bool IsActive() const { return m_isActive; }
+
+    protected:
+        void SendMessage(const MessageId messageId);
+        void ListenForMessage(const MessageId messageId);
+        void StopListeningToMessage(const MessageId messageId) const;
     };
 }

--- a/Engine/Source/MCP/Core/Application/Application.cpp
+++ b/Engine/Source/MCP/Core/Application/Application.cpp
@@ -338,7 +338,7 @@ namespace mcp
         tinyxml2::XMLDocument doc;
         if (doc.LoadFile(pGameDataFilepath) != tinyxml2::XML_SUCCESS)
         {
-            MCP_ERROR("Application", "Failed to load game data from file '%'", pGameDataFilepath);
+            MCP_ERROR("Application", "Failed to load game data from file: ", pGameDataFilepath);
             return false;
         }
 

--- a/Engine/Source/MCP/Core/Event/Message.cpp
+++ b/Engine/Source/MCP/Core/Event/Message.cpp
@@ -1,31 +1,3 @@
 // Message.cpp
 
 #include "Message.h"
-
-#include "MCP/Components/Component.h"
-#include "MCP/Scene/Object.h"
-#include "MCP/Scene/Scene.h"
-
-namespace mcp
-{
-    Messenger::Messenger(const MessageIdType id, Component* pOwner)
-        : m_pOwner(pOwner)
-        , m_id(id)
-    {
-        //
-    }
-
-    Messenger::~Messenger()
-    {
-        auto* pMessageManager = m_pOwner->GetMessageManager();
-        assert(pMessageManager);
-        pMessageManager->RemoveReceiver(m_pOwner, m_id);
-    }
-
-    void Messenger::SendMessage() const
-    {
-        auto* pMessageManager = m_pOwner->GetMessageManager();
-        assert(pMessageManager);
-        pMessageManager->QueueMessage(m_pOwner, m_id);
-    }
-}

--- a/Engine/Source/MCP/Core/Event/Message.h
+++ b/Engine/Source/MCP/Core/Event/Message.h
@@ -10,45 +10,23 @@
 //
 //-----------------------------------------------------------------------------------------------------------------------------
 
-#include "Utility/Generic/Hash.h"
+#include "Utility/String/StringId.h"
 
 namespace mcp
 {
     class Component;
-    using MessageIdType = uint32_t;
-
-#define MCP_GET_MESSAGE_ID(MessageTypeName) HashString32(#MessageTypeName)
-
-    static constexpr uint32_t GetMessageId(const char* messageTypeName) { return HashString32(messageTypeName); }
+    using MessageId = StringId;
 
     struct Message
     {
-        Component* const pSender;       // Which Component sent the message.
-        const MessageIdType id;         // Id of the message type
+        Component* const pSender;   // Which Component sent the message.
+        const MessageId id;         // Id of the message type
 
-        Message(const MessageIdType id, Component* pSender)
+        Message(const StringId id, Component* pSender)
             : pSender(pSender)
             , id(id)
         {
             //
         }
-    };
-
-    //-----------------------------------------------------------------------------------------------------------------------------
-    //		NOTES:
-    //      Do I need a MessengerId specific to this messenger? That way I can purge messages if need be.
-    //
-    ///		@brief : Messengers are simple classes that queue messages in the MessageManager of the scene.
-    //-----------------------------------------------------------------------------------------------------------------------------
-    class Messenger
-    {
-        Component* const m_pOwner;
-        const MessageIdType m_id;
-
-    public:
-        Messenger(const MessageIdType id, Component* pOwner);
-        ~Messenger();
-
-        void SendMessage() const;
     };
 }

--- a/Engine/Source/MCP/Core/Event/MessageManager.cpp
+++ b/Engine/Source/MCP/Core/Event/MessageManager.cpp
@@ -13,7 +13,7 @@ namespace mcp
             // TODO: Make sure the message.pSender is still valid? Should that matter?
 
             // If we have listeners for that message type, send the message to the receivers.
-            if (const auto result = m_messageReceivers.find(message.id); result != m_messageReceivers.end())
+            if (const auto result = m_messageListeners.find(message.id); result != m_messageListeners.end())
             {
                 for (auto* pComponent : result->second)
                 {
@@ -26,15 +26,15 @@ namespace mcp
         m_messageQueue.clear();
     }
 
-    void MessageManager::AddReceiver(Component* pReceiver, const MessageIdType id)
+    void MessageManager::AddListener(Component* pReceiver, const MessageId id)
     {
-        m_messageReceivers[id].emplace_back(pReceiver);
+        m_messageListeners[id].emplace_back(pReceiver);
     }
 
-    void MessageManager::RemoveReceiver(const Component* pReceiver, const MessageIdType id)
+    void MessageManager::RemoveListener(const Component* pReceiver, const MessageId id)
     {
         // Check to see if we have any receivers for that type.
-        if (const auto result = m_messageReceivers.find(id); result != m_messageReceivers.end())
+        if (const auto result = m_messageListeners.find(id); result != m_messageListeners.end())
         {
             // This is O(n) but I don't imagine these arrays will be huge. But who knows. Might have to
             // change later.
@@ -52,7 +52,7 @@ namespace mcp
         }
     }
 
-    void MessageManager::QueueMessage(Component* pSender, const MessageIdType id)
+    void MessageManager::QueueMessage(Component* pSender, const MessageId id)
     {
         m_messageQueue.emplace_back(id, pSender);
     }

--- a/Engine/Source/MCP/Core/Event/MessageManager.h
+++ b/Engine/Source/MCP/Core/Event/MessageManager.h
@@ -8,15 +8,15 @@ namespace mcp
 {
     class MessageManager 
     {
-        using ReceiverArray = std::vector<Component*>;
+        using Listeners = std::vector<Component*>;
 
-        std::unordered_map<MessageIdType, ReceiverArray> m_messageReceivers;
+        std::unordered_map<MessageId, Listeners, StringIdHasher> m_messageListeners;
         std::vector<Message> m_messageQueue;
 
     public:
         void ProcessMessages();
-        void AddReceiver(Component* pReceiver, const MessageIdType id);
-        void RemoveReceiver(const Component* pReceiver, const MessageIdType id);
-        void QueueMessage(Component* pSender, const MessageIdType id);
+        void AddListener(Component* pReceiver, const MessageId id);
+        void RemoveListener(const Component* pReceiver, const MessageId id);
+        void QueueMessage(Component* pSender, const MessageId id);
     };
 }


### PR DESCRIPTION
It was very silly how the API was set up for Components to send messages to each other, so I made a simple interface in the component. This is much better.

The Message system now uses StringIds! Now we aren't hashing every. single. compare. Well, we are when accessing the Message Listeners  container, but we are only hashing a pointer, and we are no longer hashing to send a message.

I also got rid of the idea of the Messenger. Seemed like a weird extra step that wasn't necessary.

Also did a second pass at the stringId API, and made accessing the static map thread safe to future proof the class.