### PR TITLE
Fixed a Bug in the Collision System, and other minor changes.

### DIFF
--- a/Engine/Source/MCP/Collision/CollisionSystem.cpp
+++ b/Engine/Source/MCP/Collision/CollisionSystem.cpp
@@ -14,7 +14,7 @@ namespace mcp
 #else
         : m_pRoot(BLEACH_NEW(QuadtreeCell(nullptr)))
 #endif
-        , m_maxTreeDepth(data.maxHeight)
+        , m_maxTreeDepth(data.maxDepth)
         , m_objectCountToTriggerDivide(data.maxObjectsInCell)
         , m_worldWidth(data.worldWidth)
         , m_worldHeight(data.worldHeight)
@@ -25,6 +25,21 @@ namespace mcp
     CollisionSystem::~CollisionSystem()
     {
         ClearTree();
+    }
+
+    //-----------------------------------------------------------------------------------------------------------------------------
+    //		NOTES:
+    //		
+    ///		@brief : Set the behavior settings for the collision system.
+    //-----------------------------------------------------------------------------------------------------------------------------
+    void CollisionSystem::SetQuadtreeBehaviorData(const QuadtreeBehaviorData& data)
+    {
+        m_worldWidth = data.worldWidth;
+        m_worldHeight = data.worldHeight;
+        m_objectCountToTriggerDivide = data.maxObjectsInCell;
+        m_maxTreeDepth = data.maxDepth;
+
+        m_pRoot->dimensions = { data.worldXPos, data.worldYPos, data.worldWidth, data.worldHeight};
     }
 
     //-----------------------------------------------------------------------------------------------------------------------------
@@ -205,7 +220,7 @@ namespace mcp
                 continue;
 
             // For each other collider component, we need to see if we collide.
-            for (auto* pComponent : pCell->m_colliderComponents)
+            for (auto& pComponent : pCell->m_colliderComponents)
             {
                 // Don't check against itself.
                 if (pComponent->m_pOwner == pColliderComponent->m_pOwner)

--- a/Engine/Source/MCP/Collision/CollisionSystem.h
+++ b/Engine/Source/MCP/Collision/CollisionSystem.h
@@ -13,7 +13,7 @@
 
 #if DEBUG_RENDER_COLLISION_TREE
     #include "MCP/Scene/IRenderable.h"
-    #include "utility/Color.h"
+    #include "Utility/Types/Color.h"
 #endif
 #else
 #define DEBUG_RENDER_COLLISION_TREE 0
@@ -27,10 +27,12 @@ namespace mcp
 
     struct QuadtreeBehaviorData
     {
-        unsigned int maxHeight          = 0;
+        unsigned int maxDepth          = 0;
         unsigned int maxObjectsInCell   = 0;
         float worldWidth                = 0.f;
         float worldHeight               = 0.f;
+        float worldXPos                 = 0.f;
+        float worldYPos                 = 0.f;
     };
 
     //-----------------------------------------------------------------------------------------------------------------------------
@@ -85,6 +87,8 @@ namespace mcp
         CollisionSystem(CollisionSystem&&) = delete;
         CollisionSystem& operator= (const CollisionSystem&) = delete;
         CollisionSystem& operator=(CollisionSystem&&) = delete;
+
+        void SetQuadtreeBehaviorData(const QuadtreeBehaviorData& data);
 
         // Collider Registration.
         void AddCollideable(ColliderComponent* pColliderComponent);

--- a/Engine/Source/MCP/Components/ColliderComponent.cpp
+++ b/Engine/Source/MCP/Components/ColliderComponent.cpp
@@ -338,6 +338,9 @@ namespace mcp
 #if RENDER_COLLIDER_VISUALS
     void ColliderComponent::Render() const
     {
+        if (!m_collisionEnabled)
+            return;
+
         for (auto& [colliderId, pCollider] : m_colliders)
         {
             pCollider->Render();

--- a/Engine/Source/MCP/Core/Resource/Parsers/XMLParser.cpp
+++ b/Engine/Source/MCP/Core/Resource/Parsers/XMLParser.cpp
@@ -105,7 +105,7 @@ namespace mcp
 
         if (errorCode == tinyxml2::XML_NO_ATTRIBUTE)
         {
-            MCP_ERROR("XML", "Failed to find Attribute named: '", pAttributeName, "' of Element: ", pElement->Name());
+            MCP_WARN("XML", "Failed to find Attribute named: '", pAttributeName, "' of Element: '", pElement->Name(), "'. Defaulting to default value.");
         }
 
         if (errorCode == tinyxml2::XML_WRONG_ATTRIBUTE_TYPE)
@@ -130,7 +130,7 @@ namespace mcp
 
         if (errorCode == tinyxml2::XML_NO_ATTRIBUTE)
         {
-            MCP_ERROR("XML", "Failed to find Attribute named: '", pAttributeName, "' of Element: ", pElement->Name());
+            MCP_WARN("XML", "Failed to find Attribute named: '", pAttributeName, "' of Element: '", pElement->Name(), "'. Defaulting to default value.");
         }
 
         if (errorCode == tinyxml2::XML_WRONG_ATTRIBUTE_TYPE)
@@ -155,7 +155,7 @@ namespace mcp
 
         if (errorCode == tinyxml2::XML_NO_ATTRIBUTE)
         {
-            MCP_ERROR("XML", "Failed to find Attribute named: '", pAttributeName, "' of Element: ", pElement->Name());
+            MCP_WARN("XML", "Failed to find Attribute named: '", pAttributeName, "' of Element: '", pElement->Name(), "'. Defaulting to default value.");
         }
 
         if (errorCode == tinyxml2::XML_WRONG_ATTRIBUTE_TYPE)
@@ -180,7 +180,7 @@ namespace mcp
 
         if (errorCode == tinyxml2::XML_NO_ATTRIBUTE)
         {
-            MCP_ERROR("XML", "Failed to find Attribute named: '", pAttributeName, "' of Element: ", pElement->Name());
+            MCP_WARN("XML", "Failed to find Attribute named: '", pAttributeName, "' of Element: '", pElement->Name(), "'. Defaulting to default value.");
         }
 
         if (errorCode == tinyxml2::XML_WRONG_ATTRIBUTE_TYPE)
@@ -205,7 +205,7 @@ namespace mcp
 
         if (errorCode == tinyxml2::XML_NO_ATTRIBUTE)
         {
-            MCP_ERROR("XML", "Failed to find Attribute named: '", pAttributeName, "' of Element: ", pElement->Name());
+            MCP_WARN("XML", "Failed to find Attribute named: '", pAttributeName, "' of Element: '", pElement->Name(), "'. Defaulting to default value.");
         }
 
         return result;

--- a/Engine/Source/MCP/Scene/Scene.cpp
+++ b/Engine/Source/MCP/Scene/Scene.cpp
@@ -6,8 +6,10 @@
 #include "IRenderable.h"
 #include "MCP/Components/ComponentFactory.h"
 #include "MCP/Components/TransformComponent.h"
+#include "MCP/Core/Application/Application.h"
 #include "MCP/Core/Resource/PackageManager.h"
 #include "MCP/Core/Resource/Parser.h"
+#include "MCP/Graphics/Graphics.h"
 #include "MCP/Scene/IUpdateable.h"
 #include "MCP/Scene/Object.h"
 
@@ -74,6 +76,24 @@ namespace mcp
             return false;
         }
 
+        // Get global settings for the Scene.
+        const XMLElement worldSettings = sceneElement.GetChildElement("WorldSettings");
+        MCP_CHECK(worldSettings.IsValid()); // This should be an assert.
+
+        // Collision Settings
+        XMLElement setting = worldSettings.GetChildElement("Collision");
+        MCP_CHECK(setting.IsValid());
+        QuadtreeBehaviorData data;
+        const auto windowDimensions = GraphicsManager::Get()->GetWindow()->GetDimensions();
+        data.worldWidth = setting.GetAttribute<float>("worldWidth", static_cast<float>(windowDimensions.width));
+        data.worldHeight = setting.GetAttribute<float>("worldHeight", static_cast<float>(windowDimensions.height));
+        data.worldXPos = setting.GetAttribute<float>("worldXPos", 0.f);
+        data.worldYPos = setting.GetAttribute<float>("worldYPos", 0.f);
+        data.maxDepth = setting.GetAttribute<unsigned>("maxDepth", 4);
+        data.maxObjectsInCell = setting.GetAttribute<unsigned>("maxObjectsInCell", 4);
+        SetCollisionSettings(data);
+
+        // Scene Objects
         XMLElement objectElement = sceneElement.GetChildElement(kObjectElementName);
         while(objectElement.IsValid())
         {
@@ -363,4 +383,10 @@ namespace mcp
 
         m_objects.clear();
     }
+
+    void Scene::SetCollisionSettings(const QuadtreeBehaviorData& data)
+    {
+        m_collisionSystem.SetQuadtreeBehaviorData(data);
+    }
+
 }

--- a/Engine/Source/MCP/Scene/Scene.h
+++ b/Engine/Source/MCP/Scene/Scene.h
@@ -35,7 +35,7 @@ namespace mcp
         std::vector<ObjectId> m_queuedObjectsToDelete;               // Objects that will be deleted at the end of the update.
         CollisionSystem m_collisionSystem;
         MessageManager m_messageManager;
-        float m_accumulatedTime;
+        float m_accumulatedTime;                                    // Amount of time before we perform a fixed update.
         bool m_transitionQueued;                                    // Whether a scene transition has been queued or not.
 
     public:
@@ -69,5 +69,6 @@ namespace mcp
         void RenderLayer(const RenderableContainer& renderables) const;
         void DeleteQueuedObjects();
         void ClearScene();
+        void SetCollisionSettings(const QuadtreeBehaviorData& data);
     };
 }


### PR DESCRIPTION
- Updated the Collider component to not render the debug visuals if the collider's collision is disabled.

- Fixed a bug in the CollisionSystem where a pointer was pointing to deleted data.

- Scene now loads Collision System behavior data from the Scene XML file.

- Set the failure to find an attribute to a warning message that explains that we will be using the default value. Sometimes not finding an attribute is the intention, so I have to decide whether I post a message at all really.