### PR TITLE
Fixed a Collision Issue, Minor Utility updates

### DIFF
--- a/Dependencies/Utility/Source/Utility/Types/Color.h
+++ b/Dependencies/Utility/Source/Utility/Types/Color.h
@@ -27,4 +27,20 @@ struct Color
     {
         //
     }
+
+    //-----------------------------------------------------------------------------------------------------------------------------
+    ///		@brief : Colors are equal if their r, g, b values are equal. We don't care about the alpha.
+    //-----------------------------------------------------------------------------------------------------------------------------
+    constexpr bool operator==(const Color& other) const
+    {
+        return r == other.r && g == other.g && b == other.b;
+    }
+
+    //-----------------------------------------------------------------------------------------------------------------------------
+    ///		@brief : Colors are not equal if their r, g, b values are not equal. We don't care about the alpha.
+    //-----------------------------------------------------------------------------------------------------------------------------
+    constexpr bool operator!=(const Color& other) const
+    {
+        return !(*this == other);
+    }
 };

--- a/Dependencies/Utility/Source/Utility/Types/Rect.h
+++ b/Dependencies/Utility/Source/Utility/Types/Rect.h
@@ -137,6 +137,11 @@ struct Rect
             && outer.y < y
             && outer.y + outer.height > y + height;
     }
+
+    std::string ToString() const
+    {
+        return CombineIntoString("(", x, ", " , y, ", ", width, ", ", height, ")");
+    }
 };
 
 using RectF = Rect<float>;

--- a/Engine/Source/MCP/Collision/CollisionSystem.cpp
+++ b/Engine/Source/MCP/Collision/CollisionSystem.cpp
@@ -290,7 +290,7 @@ namespace mcp
 
                                 const Vec2 deltaPos = significantFaceIsWidth ? Vec2{0, distanceScalar * intersectionRect.height} : Vec2 { distanceScalar * intersectionRect.width, 0.f};
 
-                                pColliderComponent->GetTransformComponent()->AddToLocation(deltaPos);
+                                pColliderComponent->GetTransformComponent()->AddToLocationNoUpdate(deltaPos);
                                 pColliderComponent->SetVelocity(significantFaceNormal * distanceOnFaceNormal);
 
                                 // Broadcast the events.
@@ -511,7 +511,7 @@ namespace mcp
     //-----------------------------------------------------------------------------------------------------------------------------
     void CollisionSystem::RemoveFromCell(QuadtreeCell* pCell, const ColliderComponent* pComponent) const
     {
-        assert(IsLeaf(pCell));
+        //assert(IsLeaf(pCell));
 
         for (size_t i = 0; i < pCell->m_colliderComponents.size(); ++i)
         {

--- a/Engine/Source/MCP/Components/ColliderComponent.cpp
+++ b/Engine/Source/MCP/Components/ColliderComponent.cpp
@@ -169,7 +169,7 @@ namespace mcp
             if (isEnabled)
             {
                 m_pSystem->AddCollideable(this);
-                m_pTransformComponent->m_onLocationUpdated.RemoveListener(this);
+                //m_pTransformComponent->m_onLocationUpdated.RemoveListener(this);
             }
             
             // Otherwise, we to remove this component from the collision tree and start listening
@@ -177,7 +177,7 @@ namespace mcp
             else
             {
                 m_pSystem->RemoveCollideable(this);
-                m_pTransformComponent->m_onLocationUpdated.AddListener(this, [this](const Vec2 pos){ this->TestCollisionNow(pos);});
+                //m_pTransformComponent->m_onLocationUpdated.AddListener(this, [this](const Vec2 pos){ this->TestCollisionNow(pos);});
             }
         }
 

--- a/Engine/Source/MCP/Components/Component.h
+++ b/Engine/Source/MCP/Components/Component.h
@@ -74,7 +74,7 @@ private:                                                                        
         //-----------------------------------------------------------------------------------------------------------------------------
         virtual void OnDestroy() {}
 
-        void SetIsActive(const bool isActive) { m_isActive = isActive; }
+        virtual void SetIsActive(const bool isActive) { m_isActive = isActive; }
 
         [[nodiscard]] virtual ComponentTypeId GetTypeId() const = 0;
         [[nodiscard]] Object* GetOwner() const { return m_pOwner; }

--- a/Engine/Source/MCP/Components/ImageComponent.cpp
+++ b/Engine/Source/MCP/Components/ImageComponent.cpp
@@ -33,16 +33,19 @@ namespace mcp
 
     ImageComponent::~ImageComponent()
     {
-        auto* pScene = m_pOwner->GetScene();
-        assert(pScene);
-        pScene->RemoveRenderable(this);
+        if (m_isActive)
+        {
+            auto* pScene = m_pOwner->GetScene();
+            MCP_CHECK(pScene);
+            pScene->RemoveRenderable(this);
+        }
     }
 
     bool ImageComponent::Init()
     {
         // Add this component to the list of renderables in the scene.
         auto* pScene = m_pOwner->GetScene();
-        assert(pScene);
+        MCP_CHECK(pScene);
         pScene->AddRenderable(this);
 
         m_pTransformComponent = m_pOwner->GetComponent<TransformComponent>();
@@ -53,6 +56,26 @@ namespace mcp
         }
 
         return true;
+    }
+
+    void ImageComponent::SetIsActive(const bool isActive)
+    {
+        if (isActive == m_isActive)
+            return;
+
+        // If we are being set to active:
+        if (isActive)
+        {
+            m_pOwner->GetScene()->AddRenderable(this);
+        }
+
+        // If we are being set to inactive.
+        else
+        {
+            m_pOwner->GetScene()->RemoveRenderable(this);
+        }
+
+        m_isActive = isActive;
     }
 
     void ImageComponent::Render() const

--- a/Engine/Source/MCP/Components/ImageComponent.h
+++ b/Engine/Source/MCP/Components/ImageComponent.h
@@ -33,6 +33,9 @@ namespace mcp
         void SetTexture(const Texture& texture) { m_texture = texture; }
         void SetCrop(const RectInt& crop) { m_crop = crop; }
         void SetSize(const float width, const float height) { m_size = { width, height }; }
+        virtual void SetIsActive(const bool isActive) override;
+
+        [[nodiscard]] RectInt GetCrop() const { return m_crop; }
 
         static bool AddFromData(const XMLElement component, Object* pOwner);
     };

--- a/Engine/Source/MCP/Components/TransformComponent.cpp
+++ b/Engine/Source/MCP/Components/TransformComponent.cpp
@@ -34,6 +34,11 @@ namespace mcp
         m_onLocationUpdated.Broadcast(m_position);
     }
 
+    void TransformComponent::AddToLocationNoUpdate(const Vec2 deltaPosition)
+    {
+        m_position += deltaPosition;
+    }
+
     void TransformComponent::SetLocation(const Vec2 position)
     {
         m_position = position;

--- a/Engine/Source/MCP/Components/TransformComponent.h
+++ b/Engine/Source/MCP/Components/TransformComponent.h
@@ -29,6 +29,7 @@ namespace mcp
         void SetLocation(const Vec2 position);
         void AddToLocation(const Vec2 deltaPosition);
         void AddToLocation(const float deltaX, const float deltaY);
+        void AddToLocationNoUpdate(const Vec2 deltaPosition);
         [[nodiscard]] Vec2 GetLocation() const { return m_position; }
             
     public:

--- a/Engine/Source/MCP/Core/Event/MessageManager.cpp
+++ b/Engine/Source/MCP/Core/Event/MessageManager.cpp
@@ -7,8 +7,14 @@ namespace mcp
 {
     void MessageManager::ProcessMessages()
     {
+        // I make a copy of the queue so that if other messages are spawned as a result of a message, those
+        // will be handled on the next call to ProcessMessages().
+        //  - I don't know if I should be handling them immediately or not.
+        const auto queue = m_messageQueue;
+        m_messageQueue.clear();
+
         // Go through the queue and dispatch the events.
-        for (auto& message : m_messageQueue)
+        for (auto& message : queue)
         {
             // TODO: Make sure the message.pSender is still valid? Should that matter?
 
@@ -21,9 +27,6 @@ namespace mcp
                 }
             }
         }
-
-        // Clear out the queue.
-        m_messageQueue.clear();
     }
 
     void MessageManager::AddListener(Component* pReceiver, const MessageId id)


### PR DESCRIPTION
- Fixed an Issue in the CollisionSystem where we were checking the collision again when 'solving' the final position of a collider. This whole transform component delegate for position changing is a bit wonky. I think I should consider making a 'moverComponent' or something and make the Transform stupid again.

- Made the 'SetActive' function in Component virtual so that components can do different things when be set active or not.

- Made the SetActive function in ImageComponent either remove or add the renderable to the scene.

-  Fixed an issue with the MessageManager where if you sent another message as the result of receiving a message, that message will be lost.

- Added the ability to update a transform location without broadcasting an event. This will probably be changed later.

- Added the ability to compare Colors

- Add a ToString for Rect.h